### PR TITLE
AbstractCommand: added common place to hook events

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         mapTestClassNameToCoveredClassName="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false">
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix=".php">./tests/Tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <php>
+    <ini name="memory_limit" value="-1"/>
+  </php>
+
+  <filter>
+    <blacklist>
+      <directory>./vendor</directory>
+      <directory>./tests/</directory>
+    </blacklist>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">./library</directory>
+    </whitelist>
+  </filter>
+
+</phpunit>


### PR DESCRIPTION
Give a downstream implementer a funnel to "catch" all events as they flow through the system. With this, I could easily add an event system (such as Symfony EventDispatcher/Zend Event Manager) to be quickly snapped in by extending AbstractCommand -- Long term could have pluggable systems for either
Allows phpunit to be run from source root as ./vendor/bin/phpunit
Ensure that metrics/circuitbreakers are updated before events are "called" -- just incase the event solution goes off the rails :)

From https://github.com/odesk/phystrix/pull/8