### PR TITLE
Feature optional injections

### DIFF
--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -199,6 +199,10 @@ abstract class AbstractCommand
      */
     private function isRequestCacheEnabled()
     {
+        if (!$this->requestCache) {
+            return false;
+        }
+
         return $this->config->get('requestCache')->get('enabled') && $this->getCacheKey() !== null;
     }
 
@@ -213,10 +217,13 @@ abstract class AbstractCommand
     {
         $this->prepare();
         $metrics = $this->getMetrics();
+        $cache_enabled = $this->isRequestCacheEnabled();
+
         // always adding the command to request log
         $this->recordExecutedCommand();
+
         // trying from cache first
-        if ($this->isRequestCacheEnabled()) {
+        if ($cache_enabled) {
             $fromCache = $this->requestCache->get($this->getCommandKey(), $this->getCacheKey());
             if ($fromCache !== null) {
                 $this->executionEvents[] = self::EVENT_RESPONSE_FROM_CACHE;
@@ -250,9 +257,10 @@ abstract class AbstractCommand
         }
 
         // putting the result into cache
-        if ($this->isRequestCacheEnabled()) {
+        if ($cache_enabled) {
             $this->requestCache->put($this->getCommandKey(), $this->getCacheKey(), $result);
         }
+
         return $result;
     }
 

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -428,7 +428,7 @@ abstract class AbstractCommand
      */
     private function recordExecutedCommand()
     {
-        if ($this->config->get('requestLog')->get('enabled')) {
+        if ($this->requestLog && $this->config->get('requestLog')->get('enabled') ) {
             $this->requestLog->addExecutedCommand($this);
         }
     }

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -74,7 +74,7 @@ class CommandFactory
         CircuitBreakerFactory $circuitBreakerFactory,
         CommandMetricsFactory $commandMetricsFactory,
         RequestCache $requestCache,
-        RequestLog $requestLog
+        RequestLog $requestLog = null
     ) {
         $this->serviceLocator = $serviceLocator;
         $this->config = $config;
@@ -106,7 +106,10 @@ class CommandFactory
         $command->setServiceLocator($this->serviceLocator);
         $command->initializeConfig($this->config);
         $command->setRequestCache($this->requestCache);
-        $command->setRequestLog($this->requestLog);
+
+        if ($this->requestLog) {
+            $command->setRequestLog($this->requestLog);
+        }
 
         return $command;
     }

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -73,15 +73,15 @@ class CommandFactory
         LocatorInterface $serviceLocator,
         CircuitBreakerFactory $circuitBreakerFactory,
         CommandMetricsFactory $commandMetricsFactory,
-        RequestCache $requestCache,
+        RequestCache $requestCache = null,
         RequestLog $requestLog = null
     ) {
         $this->serviceLocator = $serviceLocator;
         $this->config = $config;
         $this->circuitBreakerFactory = $circuitBreakerFactory;
+        $this->commandMetricsFactory = $commandMetricsFactory;
         $this->requestCache = $requestCache;
         $this->requestLog = $requestLog;
-        $this->commandMetricsFactory = $commandMetricsFactory;
     }
 
     /**
@@ -105,7 +105,10 @@ class CommandFactory
         $command->setCommandMetricsFactory($this->commandMetricsFactory);
         $command->setServiceLocator($this->serviceLocator);
         $command->initializeConfig($this->config);
-        $command->setRequestCache($this->requestCache);
+
+        if ($this->requestCache) {
+            $command->setRequestCache($this->requestCache);
+        }
 
         if ($this->requestLog) {
             $command->setRequestLog($this->requestLog);

--- a/tests/Tests/Odesk/Phystrix/CommandTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandTest.php
@@ -190,7 +190,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     /**
      * Ensure command does not break when configured to log, though one hasn't been injected
      *
-     * @dataProvider requestConfigBoolProvider
+     * @dataProvider configBoolProvider
      *
      * @param bool $log_enabled  whether config is set to use request log
      */
@@ -199,8 +199,9 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         // Duplicate some of the class setup in order to bypass requestLog generation
         $command = new CommandMock();
         $command->setCommandMetricsFactory($this->commandMetricsFactory);
-        $command->setRequestCache(new RequestCache());
         $command->setCircuitBreakerFactory($this->circuitBreakerFactory);
+        $command->setRequestCache(new RequestCache());
+
         $command->setConfig(new \Zend\Config\Config(array(
             'requestLog' => array(
                 'enabled' => $log_enabled,
@@ -213,13 +214,40 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensure command does not break when configured to cache, though cache hasn't been injected
+     *
+     * @dataProvider configBoolProvider
+     *
+     * @param bool $cache_enabled  whether config is set to use request log
+     */
+    public function testRequestCacheNotInjected($cache_enabled) {
+
+        // Duplicate some of the class setup in order to bypass requestLog generation
+        $command = new CommandMock();
+        $command->setCommandMetricsFactory($this->commandMetricsFactory);
+        $command->setCircuitBreakerFactory($this->circuitBreakerFactory);
+        $command->setRequestLog($this->requestLog);
+
+        $command->setConfig(new \Zend\Config\Config(array(
+            'requestCache' => array(
+                'enabled' => $cache_enabled,
+            ),
+        ), true));
+
+        $this->setUpCommonExpectations();
+
+        $this->assertEquals('run result', $this->command->execute());
+    }
+
+
+    /**
      * @return array
      */
-    public function requestConfigBoolProvider() {
+    public function configBoolProvider() {
 
         return [
-            'requestLog config enabled'  => [ true ],
-            'requestLog config disabled' => [ false ],
+            'config enabled'  => [ true ],
+            'config disabled' => [ false ],
         ];
     }
 

--- a/tests/Tests/Odesk/Phystrix/CommandTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandTest.php
@@ -187,6 +187,42 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->requestLog->getExecutedCommands());
     }
 
+    /**
+     * Ensure command does not break when configured to log, though one hasn't been injected
+     *
+     * @dataProvider requestConfigBoolProvider
+     *
+     * @param bool $log_enabled  whether config is set to use request log
+     */
+    public function testRequestLogNotInjected($log_enabled) {
+
+        // Duplicate some of the class setup in order to bypass requestLog generation
+        $command = new CommandMock();
+        $command->setCommandMetricsFactory($this->commandMetricsFactory);
+        $command->setRequestCache(new RequestCache());
+        $command->setCircuitBreakerFactory($this->circuitBreakerFactory);
+        $command->setConfig(new \Zend\Config\Config(array(
+            'requestLog' => array(
+                'enabled' => $log_enabled,
+            ),
+        ), true));
+
+        $this->setUpCommonExpectations();
+
+        $this->assertEquals('run result', $this->command->execute());
+    }
+
+    /**
+     * @return array
+     */
+    public function requestConfigBoolProvider() {
+
+        return [
+            'requestLog config enabled'  => [ true ],
+            'requestLog config disabled' => [ false ],
+        ];
+    }
+
     public function testExecuteRequestNotAllowed()
     {
         $this->setUpCommonExpectations(false);
@@ -228,7 +264,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(555, $this->command->getExecutionTimeInMilliseconds());
         $this->assertEquals(new \DomainException('could not run'), $this->command->getExecutionException());
     }
-    
+
     public function testExecuteFallbackFailed()
     {
         $this->setUpCommonExpectations();


### PR DESCRIPTION
From: https://github.com/odesk/phystrix/pull/9

In order to simplify CommandFactory setup, where requestLog and requestCache are not used, make these dependencies optional